### PR TITLE
Support for programmable renderer and alpha channel of the source texture.

### DIFF
--- a/src/ofxGpuLut.cpp
+++ b/src/ofxGpuLut.cpp
@@ -34,12 +34,12 @@ void ofxGpuLut::load(ofTexture lutTexture){
 }
 
 void ofxGpuLut::load(ofImage lutImage){
-    load(lutImage.getTextureReference());
+    load(lutImage.getTexture());
 }
 
 void ofxGpuLut::load(string path){
-    lutImage.loadImage(path);
-    load(lutImage.getTextureReference());
+    lutImage.load(path);
+    load(lutImage.getTexture());
 }
 
 void ofxGpuLut::begin(){

--- a/src/ofxGpuLut.cpp
+++ b/src/ofxGpuLut.cpp
@@ -13,12 +13,22 @@ void ofxGpuLut::load(ofTexture lutTexture){
                                 
                                 void main( void )
                                 {
-                                    vec3 originalColor = floor(texture2DRect(tex, gl_TexCoord[0].st).rgb * vec3(size - 1.0));
-                                    vec2 blueIndex = vec2(mod(originalColor.b, sqrt(size)), floor(originalColor.b / sqrt(size)));
-                                    vec2 index = vec2((size * blueIndex.x + originalColor.r) + 0.5, (size * blueIndex.y + originalColor.g) + 0.5);
-                                    gl_FragColor = vec4(texture2DRect(lut, index).rgb, 1.0);
+                                    vec3 rawColor = texture2DRect(tex, gl_TexCoord[0].st).rgb;
+                                    float rawAlpha = texture2DRect(tex, gl_TexCoord[0].st).a;
+                                    
+                                    if (rawAlpha <= 0.0) {
+                                        gl_FragColor = vec4(rawColor, 0.0);
+                                    }
+                                    else {
+                                        vec3 originalColor = floor(texture2DRect(tex, gl_TexCoord[0].st).rgb * vec3(size - 1.0));
+                                        vec2 blueIndex = vec2(mod(originalColor.b, sqrt(size)), floor(originalColor.b / sqrt(size)));
+                                        vec2 index = vec2((size * blueIndex.x + originalColor.r) + 0.5, (size * blueIndex.y + originalColor.g) + 0.5);
+                                        gl_FragColor = vec4(texture2DRect(lut, index).rgb, rawAlpha);
+                                    }
                                 }
                                 );
+    
+    
     lutShader.unload();
     lutShader.setupShaderFromSource(GL_FRAGMENT_SHADER, fragmentShader);
     lutShader.linkProgram();

--- a/src/ofxGpuLut.cpp
+++ b/src/ofxGpuLut.cpp
@@ -4,34 +4,93 @@ ofxGpuLut::ofxGpuLut(){}
 ofxGpuLut::~ofxGpuLut(){}
 
 void ofxGpuLut::load(ofTexture lutTexture){
-    fragmentShader = "#version 120\n#extension GL_ARB_texture_rectangle : enable\n";
-    fragmentShader += STRINGIFY(
-                                uniform sampler2DRect tex;
-                                uniform sampler2DRect lut;
-                                
-                                float size = 64.0;
-                                
-                                void main( void )
-                                {
-                                    vec3 rawColor = texture2DRect(tex, gl_TexCoord[0].st).rgb;
-                                    float rawAlpha = texture2DRect(tex, gl_TexCoord[0].st).a;
+    
+    if(ofIsGLProgrammableRenderer()){
+        vertexShader = "#version 150\n";
+        vertexShader += STRINGIFY(
+                                  uniform mat4 projectionMatrix;
+                                  uniform mat4 modelViewMatrix;
+                                  uniform mat4 modelViewProjectionMatrix;
+                                  
+                                  in vec4  position;
+                                  in vec2  texcoord;
+                                  
+                                  out vec2 texCoordVarying;
+                                  
+                                  void main()
+                                  {
+                                      texCoordVarying = texcoord;
+                                      gl_Position = modelViewProjectionMatrix * position;
+                                  }
+                                  );
+        
+        fragmentShader = "#version 150\n";
+        fragmentShader += STRINGIFY(
+                                    uniform sampler2DRect tex;
+                                    uniform sampler2DRect lut;
                                     
-                                    if (rawAlpha <= 0.0) {
-                                        gl_FragColor = vec4(rawColor, 0.0);
+                                    in vec2 texCoordVarying;
+                                    
+                                    out vec4 fragColor;
+                                    
+                                    // Texture coordinates
+                                    vec2 texcoord0 = texCoordVarying;
+                                    
+                                    float size = 64.0;
+                                    
+                                    void main( void )
+                                    {
+                                        vec3 rawColor = texture(tex, texcoord0).rgb;
+                                        float rawAlpha = texture(tex, texcoord0).a;
+                                        
+                                        if (rawAlpha <= 0.0) {
+                                            fragColor = vec4(rawColor, 0.0);
+                                        }
+                                        else {
+                                            vec3 originalColor = floor(texture(tex, texcoord0).rgb * vec3(size - 1.0));
+                                            vec2 blueIndex = vec2(mod(originalColor.b, sqrt(size)), floor(originalColor.b / sqrt(size)));
+                                            vec2 index = vec2((size * blueIndex.x + originalColor.r) + 0.5, (size * blueIndex.y + originalColor.g) + 0.5);
+                                            fragColor = vec4(texture(lut, index).rgb, rawAlpha);
+                                        }
                                     }
-                                    else {
-                                        vec3 originalColor = floor(texture2DRect(tex, gl_TexCoord[0].st).rgb * vec3(size - 1.0));
-                                        vec2 blueIndex = vec2(mod(originalColor.b, sqrt(size)), floor(originalColor.b / sqrt(size)));
-                                        vec2 index = vec2((size * blueIndex.x + originalColor.r) + 0.5, (size * blueIndex.y + originalColor.g) + 0.5);
-                                        gl_FragColor = vec4(texture2DRect(lut, index).rgb, rawAlpha);
+                                    );
+        
+        lutShader.setupShaderFromSource(GL_VERTEX_SHADER, vertexShader);
+        lutShader.setupShaderFromSource(GL_FRAGMENT_SHADER, fragmentShader);
+        lutShader.bindDefaults();
+        lutShader.linkProgram();
+    }
+    else {
+        fragmentShader = "#version 120\n#extension GL_ARB_texture_rectangle : enable\n";
+        fragmentShader += STRINGIFY(
+                                    uniform sampler2DRect tex;
+                                    uniform sampler2DRect lut;
+                                    
+                                    float size = 64.0;
+                                    
+                                    void main( void )
+                                    {
+                                        vec3 rawColor = texture2DRect(tex, gl_TexCoord[0].st).rgb;
+                                        float rawAlpha = texture2DRect(tex, gl_TexCoord[0].st).a;
+                                        
+                                        if (rawAlpha <= 0.0) {
+                                            gl_FragColor = vec4(rawColor, 0.0);
+                                        }
+                                        else {
+                                            vec3 originalColor = floor(texture2DRect(tex, gl_TexCoord[0].st).rgb * vec3(size - 1.0));
+                                            vec2 blueIndex = vec2(mod(originalColor.b, sqrt(size)), floor(originalColor.b / sqrt(size)));
+                                            vec2 index = vec2((size * blueIndex.x + originalColor.r) + 0.5, (size * blueIndex.y + originalColor.g) + 0.5);
+                                            gl_FragColor = vec4(texture2DRect(lut, index).rgb, rawAlpha);
+                                        }
                                     }
-                                }
-                                );
+                                    );
+        
+        
+        lutShader.unload();
+        lutShader.setupShaderFromSource(GL_FRAGMENT_SHADER, fragmentShader);
+        lutShader.linkProgram();
+    }
     
-    
-    lutShader.unload();
-    lutShader.setupShaderFromSource(GL_FRAGMENT_SHADER, fragmentShader);
-    lutShader.linkProgram();
     lut.setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
     lut.setTextureMinMagFilter(GL_NEAREST, GL_NEAREST);
     if(!ofGetUsingArbTex()){

--- a/src/ofxGpuLut.h
+++ b/src/ofxGpuLut.h
@@ -9,6 +9,7 @@ class ofxGpuLut{
 private:
     ofShader lutShader;
     ofTexture lut;
+    string vertexShader;
     string fragmentShader;
     ofImage lutImage;
 public:


### PR DESCRIPTION
Hi,

Here is a PR including 3 things...

1-
Changed two methods calls to support OF 0.9.0.

2-
The addon can now use both the 'gl renderer' and the 'gl programmable renderer'. To do so I have added a version of the shaders using glsl v150. To easily switch from the 'gl renderer' to the 'gl programmable renderer' just change the version of openGL used in the main.h header file.

```
int main( ){
    ofGLWindowSettings settings;
    settings.setGLVersion(3, 2); // Using programmable renderer. Comment out this line to use the 'standard' GL renderer.
    settings.width = 1024;
    settings.height = 768;
    ofCreateWindow(settings);
    ofRunApp(new ofApp());
}
```

3-
Have also modified the shader in order to take in account the alpha channel of the source image.

Let me know what you think of these.

Cheers!
